### PR TITLE
feat: adiciona menu de outras cidades

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,6 +5,7 @@ menu:
 
   - {name: 'Eventos', url: '/events'}
   - {name: 'Meetup', url: 'https://evento.so/brbitdevs', external: true}
+  - {name: 'Outras Cidades', url: '/cities'}
 
 social:
   x:

--- a/cities.md
+++ b/cities.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Outras Cidades
+---
+<div class="Home">
+    <p class="Home-about">
+        O formato BitDevs se espalhou por várias cidades do Brasil. Se você estiver viajando ou quiser conhecer outras comunidades, aqui vai uma lista com alguns grupos ativos.
+    </p>
+
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do Brasil</h2>
+        <ul>
+            <li><a href="https://bhbitdevs.org/" target="_blank" rel="noopener nofollow">Belo Horizonte</a></li>
+            <li><a href="https://bitdevs.bsb.br/" target="_blank" rel="noopener nofollow">Brasília</a></li>
+            <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
+            <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
+            <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
+        </ul>
+    </div>
+
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do mundo</h2>
+        <p>
+            <a href="https://bitdevs.org/cities" target="_blank" rel="noopener nofollow">
+                Ver a lista global mantida pelo BitDevs NYC
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
## Resumo
- adiciona a aba `Outras Cidades` no menu principal
- cria/atualiza a página `/cities` com links para os outros BitDevs do Brasil
- mantém um link separado para a lista global do BitDevs NYC

## Validação
- `git diff --check`

Closes #87
