### PR TITLE
feat: add Uberlândia to city list

### DIFF
--- a/cities.md
+++ b/cities.md
@@ -15,6 +15,7 @@ title: Outras Cidades
             <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
             <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
             <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
+            <li><a href="https://udibitdevs.org/" target="_blank" rel="noopener nofollow">Uberlândia</a></li>
         </ul>
     </div>
 


### PR DESCRIPTION
Adds Uberlândia to the "Outras Cidades" list.

This keeps the Brazilian city list in sync with the other BitDevs sites.