### PR TITLE
fix: replica ajuste de navegacao de cidades do Curitiba

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,7 +5,7 @@ menu:
 
   - {name: 'Eventos', url: '/events'}
   - {name: 'Meetup', url: 'https://evento.so/brbitdevs', external: true}
-  - {name: 'Outras Cidades', url: '/cities'}
+  - {name: 'Cidades', url: '/cities'}
 
 social:
   x:

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -56,6 +56,7 @@
   &-logo-text {
     margin-left: 0;
     font-size: 2.1rem;
+    white-space: nowrap;
 
     @media (min-width: 768px) {
       margin-left: 0.5rem;
@@ -81,6 +82,7 @@
       color: var(--font-color);
       opacity: 0.4;
       margin-right: 1rem;
+      white-space: nowrap;
 
       @media (min-width: 768px) {
         margin-right: 0;

--- a/cities.md
+++ b/cities.md
@@ -1,6 +1,7 @@
 ---
 layout: default
-title: Outras Cidades
+title: Cidades
+permalink: /cities/
 ---
 <div class="Home">
     <p class="Home-about">


### PR DESCRIPTION
## Resumo

Replica neste site o ajuste proposto em `curitibabitdevs/curitibabitdevs.org#51` para a navegacao de cidades, mantendo consistencia com os outros BitDevs e evitando quebra de linha no header.

## Mudancas

- renomeia `Outras Cidades` para `Cidades`
- usa `permalink: /cities/`
- aplica `white-space: nowrap` no titulo/logo e nos links do header

## Referencia

- https://github.com/curitibabitdevs/curitibabitdevs.org/pull/51